### PR TITLE
feat: configure API Gateway routing and global auth filter

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -39,23 +39,38 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
 		</dependency>
+		<!-- Security es necesaria para OAuth2 Resource Server -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
+
+		<!-- Spring Cloud Gateway (Reactivo) -->
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-gateway-mvc</artifactId>
+			<artifactId>spring-cloud-starter-gateway</artifactId>
 		</dependency>
+
+
+		<!-- LoadBalancer es útil con Service Discovery -->
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-loadbalancer</artifactId>
 		</dependency>
+
+		<!-- Eureka Client para registro y descubrimiento de servicios -->
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
 		</dependency>
 
+		<!-- WebFlux es la base reactiva, Gateway ya lo incluye transitivamente, pero no daña tenerlo explícito -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+
+		<!-- Dependencias de Test -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -67,6 +82,8 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<!-- Gestiona las versiones de las dependencias de Spring Cloud -->
 	<dependencyManagement>
 		<dependencies>
 			<dependency>

--- a/api-gateway/src/main/java/com/gimnasio/apigateway/config/GatewayConfig.java
+++ b/api-gateway/src/main/java/com/gimnasio/apigateway/config/GatewayConfig.java
@@ -1,0 +1,30 @@
+package com.gimnasio.apigateway.config;
+
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+@Configuration
+public class GatewayConfig {
+
+    @Bean
+    public GlobalFilter customGlobalFilter() {
+        return (exchange, chain) -> {
+            ServerHttpRequest req = exchange.getRequest();
+            String auth = req.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+            if (auth != null) {
+                return chain.filter(
+                        exchange.mutate()
+                                .request(req.mutate()
+                                        .header(HttpHeaders.AUTHORIZATION, auth)
+                                        .build())
+                                .build()
+                );
+            }
+            return chain.filter(exchange);
+        };
+    }
+
+}

--- a/api-gateway/src/main/resources/application.properties
+++ b/api-gateway/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=api-gateway

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -1,0 +1,60 @@
+server:
+  port: 8080 # Puerto para API Gateway
+
+spring:
+  application:
+    name: apigateway
+
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:9090/realms/gym
+
+  main:
+    allow-bean-definition-overriding: true
+
+  cloud:
+    gateway:
+      # Aquí es donde se definen las rutas
+      routes:
+        - id: equipment-service
+          uri: http://localhost:8081 # URI de tu microservicio de equipamiento
+          predicates:
+            - Path=/equipment/** # Peticiones que coincidan con este path
+          filters: # Añadido para consistencia, aunque no sea estrictamente necesario aquí si /equipment/** es la raíz
+            - StripPrefix=1
+
+        - id: member-service
+          uri: http://localhost:8080 # URI de tu microservicio de miembros
+          predicates:
+            - Path=/members/**
+          filters: # <-- AÑADIDO
+            - StripPrefix=1  # <-- AÑADIDO: Elimina el /members antes de enviar a 8080
+
+        - id: class-service
+          uri: http://localhost:8083 # URI de tu microservicio de clases
+          predicates:
+            - Path=/classes/**
+          filters: # Añadido para consistencia
+            - StripPrefix=1
+
+        - id: trainers-service
+          uri: http://localhost:8084 # URI de tu microservicio de entrenadores
+          predicates:
+            - Path=/trainers/**
+          filters: # Añadido para consistencia
+            - StripPrefix=1
+
+        - id: notifications-service
+          uri: http://localhost:8086 # URI de tu microservicio de notificaciones
+          predicates:
+            - Path=/notifications/**
+          filters: # Añadido para consistencia
+            - StripPrefix=1
+
+# Configuración de logging
+logging:
+  level:
+    org.springframework.cloud.gateway: DEBUG
+    reactor.netty: DEBUG


### PR DESCRIPTION
Added route definitions in application.yml for equipment, members, classes, trainers, and notifications services with StripPrefix filters. Set up OAuth2 JWT resource server pointing to Keycloak issuer. Implemented a global filter in GatewayConfig.java to propagate Authorization header in all requests.